### PR TITLE
move vault-init out of being a ui init container and run it as a job instead

### DIFF
--- a/makefile
+++ b/makefile
@@ -218,16 +218,19 @@ dev-deploy-force:
 dev-apply:
 	kustomize build zarf/k8s/dev/vault | kubectl apply -f -
 
+	kustomize build zarf/k8s/dev/vault-init | kubectl apply -f -
+	kubectl wait --timeout=120s --namespace=liars-system --for=condition=Complete job/vault-init
+
 	kustomize build zarf/k8s/dev/geth | kubectl apply -f -
 	kubectl wait --timeout=120s --namespace=liars-system --for=condition=Available deployment/geth
-
-	kustomize build zarf/k8s/dev/ui | kubectl apply -f -
-	kubectl wait --timeout=120s --namespace=liars-system --for=condition=Available deployment/ui
 
 	@zarf/k8s/dev/geth/setup-contract-k8s
 
 	kustomize build zarf/k8s/dev/engine | kubectl apply -f -
 	kubectl wait --timeout=120s --namespace=liars-system --for=condition=Available deployment/engine
+
+	kustomize build zarf/k8s/dev/ui | kubectl apply -f -
+	kubectl wait --timeout=120s --namespace=liars-system --for=condition=Available deployment/ui
 
 dev-restart:
 	kubectl rollout restart deployment sales --namespace=liars-system

--- a/zarf/k8s/base/ui/base-ui.yaml
+++ b/zarf/k8s/base/ui/base-ui.yaml
@@ -18,18 +18,6 @@ spec:
         app: ui
     spec:
       terminationGracePeriodSeconds: 60
-      volumes:
-        - name: vault
-          persistentVolumeClaim:
-            claimName: vault-credentials
-      initContainers:
-      # game-engine init container configuration
-      - name: init-vault-server
-        image: game-engine-image
-        command: ['./admin', '-v']
-        volumeMounts:
-          - name: vault
-            mountPath: /vault
       containers:
       # game-engine container configuration
       - name: game-ui

--- a/zarf/k8s/dev/ui/kustomization.yaml
+++ b/zarf/k8s/dev/ui/kustomization.yaml
@@ -8,6 +8,3 @@ images:
   - name: game-ui-image
     newName: liarsdice-game-ui
     newTag: "1.0"
-  - name: game-engine-image
-    newName: liarsdice-game-engine
-    newTag: "1.0"

--- a/zarf/k8s/dev/vault-init/kustomization.yaml
+++ b/zarf/k8s/dev/vault-init/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./vault-init.yaml
+images:
+  - name: game-engine-image
+    newName: liarsdice-game-engine
+    newTag: "1.0"

--- a/zarf/k8s/dev/vault-init/vault-init.yaml
+++ b/zarf/k8s/dev/vault-init/vault-init.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: vault-init
+  namespace: liars-system
+spec:
+  template:
+    spec:
+      volumes:
+        - name: vault
+          persistentVolumeClaim:
+            claimName: vault-credentials
+      containers:
+      - name: vault-init
+        image: game-engine-image
+        command: ['./admin', '-v']
+        volumeMounts:
+          - name: vault
+            mountPath: /vault
+      restartPolicy: Never


### PR DESCRIPTION
Vault is now initialized/unsealed via a k8s job instead of being an init container in ui.