### PR TITLE
Move initialization out of init containers and into local processes

### DIFF
--- a/app/services/engine/main.go
+++ b/app/services/engine/main.go
@@ -153,7 +153,7 @@ func run(log *zap.SugaredLogger) error {
 
 	log.Infow("startup", "status", "initializing authentication support")
 
-	vaultConfig, err := vault.New(vault.Config{
+	vaultClient, err := vault.New(vault.Config{
 		Address:   cfg.Vault.Address,
 		Token:     cfg.Vault.Token,
 		MountPath: cfg.Vault.MountPath,
@@ -164,7 +164,7 @@ func run(log *zap.SugaredLogger) error {
 
 	authCfg := auth.Config{
 		Log:       log,
-		KeyLookup: vaultConfig,
+		KeyLookup: vaultClient,
 	}
 
 	authClient, err := auth.New(authCfg)

--- a/app/services/engine/main.go
+++ b/app/services/engine/main.go
@@ -173,7 +173,7 @@ func run(log *zap.SugaredLogger) error {
 	}
 
 	// =========================================================================
-	// Create the currency converter and bank needed for the game
+	// Create the currency converter and bankClient needed for the game
 
 	if cfg.Game.ContractID == "0x0" {
 		return errors.New("smart contract id not provided")
@@ -204,9 +204,9 @@ func run(log *zap.SugaredLogger) error {
 		return errors.New("capture private key")
 	}
 
-	bank, err := bank.New(ctx, log, backend, privateKey, common.HexToAddress(cfg.Game.ContractID))
+	bankClient, err := bank.New(ctx, log, backend, privateKey, common.HexToAddress(cfg.Game.ContractID))
 	if err != nil {
-		return fmt.Errorf("connecting to bank: %w", err)
+		return fmt.Errorf("connecting to bankClient: %w", err)
 	}
 
 	// =========================================================================
@@ -244,7 +244,7 @@ func run(log *zap.SugaredLogger) error {
 		Log:            log,
 		Auth:           authClient,
 		Converter:      converter,
-		Bank:           bank,
+		Bank:           bankClient,
 		Evts:           evts,
 		AnteUSD:        cfg.Game.AnteUSD,
 		ActiveKID:      cfg.Auth.ActiveKID,

--- a/app/services/engine/main.go
+++ b/app/services/engine/main.go
@@ -98,7 +98,7 @@ func run(log *zap.SugaredLogger) error {
 			DebugHost       string        `conf:"default:0.0.0.0:4000"`
 		}
 		Vault struct {
-			Address   string `conf:"default:http://vault-service.liars-system.svc.cluster.local:8200"`
+			Address   string `conf:"default:http://vaultConfig-service.liars-system.svc.cluster.local:8200"`
 			MountPath string `conf:"default:secret"`
 			Token     string `conf:"default:mytoken,mask"`
 		}
@@ -153,23 +153,23 @@ func run(log *zap.SugaredLogger) error {
 
 	log.Infow("startup", "status", "initializing authentication support")
 
-	vault, err := vault.New(vault.Config{
+	vaultConfig, err := vault.New(vault.Config{
 		Address:   cfg.Vault.Address,
 		Token:     cfg.Vault.Token,
 		MountPath: cfg.Vault.MountPath,
 	})
 	if err != nil {
-		return fmt.Errorf("constructing vault: %w", err)
+		return fmt.Errorf("constructing vaultConfig: %w", err)
 	}
 
 	authCfg := auth.Config{
 		Log:       log,
-		KeyLookup: vault,
+		KeyLookup: vaultConfig,
 	}
 
-	auth, err := auth.New(authCfg)
+	authClient, err := auth.New(authCfg)
 	if err != nil {
-		return fmt.Errorf("constructing auth: %w", err)
+		return fmt.Errorf("constructing authClient: %w", err)
 	}
 
 	// =========================================================================
@@ -242,7 +242,7 @@ func run(log *zap.SugaredLogger) error {
 	apiMux := handlers.APIMux(handlers.APIMuxConfig{
 		Shutdown:       shutdown,
 		Log:            log,
-		Auth:           auth,
+		Auth:           authClient,
 		Converter:      converter,
 		Bank:           bank,
 		Evts:           evts,

--- a/app/tooling/admin/cmd/vault_init.go
+++ b/app/tooling/admin/cmd/vault_init.go
@@ -34,7 +34,7 @@ var vaultInitCmd = &cobra.Command{
 	},
 }
 
-const defaultCredentialFile = "/vault/credentials.json"
+const defaultCredentialFile = "/tmp/credentials.json"
 
 func init() {
 	vaultCmd.AddCommand(vaultInitCmd)

--- a/makefile
+++ b/makefile
@@ -204,6 +204,7 @@ dev-up:
 dev-down:
 	telepresence quit -s
 	kind delete cluster --name $(KIND_CLUSTER)
+	rm -f /tmp/credentials.json
 
 dev-load:
 	kind load docker-image liarsdice-game-engine:$(VERSION) --name $(KIND_CLUSTER)
@@ -215,19 +216,21 @@ dev-deploy:
 dev-deploy-force:
 	@zarf/k8s/dev/geth/setup-contract-k8s force
 
-dev-apply:
+dev-apply: admin-build
 	kustomize build zarf/k8s/dev/vault | kubectl apply -f -
+
+	@zarf/k8s/dev/vault/initialize_vault.sh
 
 	kustomize build zarf/k8s/dev/geth | kubectl apply -f -
 	kubectl wait --timeout=120s --namespace=liars-system --for=condition=Available deployment/geth
-
-	kustomize build zarf/k8s/dev/ui | kubectl apply -f -
-	kubectl wait --timeout=120s --namespace=liars-system --for=condition=Available deployment/ui
 
 	@zarf/k8s/dev/geth/setup-contract-k8s
 
 	kustomize build zarf/k8s/dev/engine | kubectl apply -f -
 	kubectl wait --timeout=120s --namespace=liars-system --for=condition=Available deployment/engine
+
+	kustomize build zarf/k8s/dev/ui | kubectl apply -f -
+	kubectl wait --timeout=120s --namespace=liars-system --for=condition=Available deployment/ui
 
 dev-restart:
 	kubectl rollout restart deployment engine --namespace=liars-system

--- a/makefile
+++ b/makefile
@@ -173,7 +173,6 @@ game-engine:
 		-t liarsdice-game-engine:$(VERSION) \
 		--build-arg BUILD_REF=$(VERSION) \
 		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
-		--load \
 		.
 
 ui:
@@ -182,7 +181,6 @@ ui:
 		-t liarsdice-game-ui:$(VERSION) \
 		--build-arg BUILD_REF=$(VERSION) \
 		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
-		--load \
 		.
 
 # ==============================================================================

--- a/zarf/k8s/base/engine/base-engine.yaml
+++ b/zarf/k8s/base/engine/base-engine.yaml
@@ -3,19 +3,6 @@ kind: Namespace
 metadata:
   name: liars-system
 ---
-# We need the vault credentials to exist across pod restarts
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  namespace: liars-system
-  name: vault-credentials
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 1Gi
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -31,20 +18,6 @@ spec:
         app: engine
     spec:
       terminationGracePeriodSeconds: 60
-      volumes:
-        - name: vault
-          persistentVolumeClaim:
-            claimName: vault-credentials
-      initContainers:
-      - name: init-vault-server
-        image: game-engine-image
-        command: ['./admin', 'vault', 'init']
-        volumeMounts:
-          - name: vault
-            mountPath: /vault
-      - name: init-vault-keys
-        image: game-engine-image
-        command: ['./admin', 'vault', 'add-keys']
       containers:
       - name: game-engine
         image: game-engine-image

--- a/zarf/k8s/dev/vault/initialize_vault.sh
+++ b/zarf/k8s/dev/vault/initialize_vault.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+get_pod_status () {
+  kubectl -n liars-system get pods vault-0 > /dev/null 2>&1
+  RET=${?}
+
+  if [ "${RET}" -ne 0 ]; then
+    echo "Not running"
+    exit
+  fi
+
+  kubectl -n liars-system get pods -o jsonpath='{.items[0].status.phase}'
+}
+
+echo "Waiting for vault pod to enter the Running state"
+while [ $(get_pod_status) != "Running" ]; do
+  sleep 1
+done
+
+echo "Initializing vault"
+./admin vault init
+RET=${?}
+
+if [ "${RET}" -ne 0 ]; then
+  exit "${RET}"
+fi
+
+echo "Adding pem keys"
+./admin vault add-keys


### PR DESCRIPTION
This moves vault initialization and unsealing as well as pem key loading out of init container to make it easier to work with. Now we can run `admin` locally and achieve the same results.